### PR TITLE
Implement multiple underscores in numeric literals

### DIFF
--- a/examples/parser.rs
+++ b/examples/parser.rs
@@ -9,7 +9,8 @@ fn main() {
     // let valid_parser_code = String::from("5,");
     // let valid_parser_code = String::from("5,6");
     // let valid_parser_code = String::from("(5,)");
-    let valid_parser_code = String::from("(5,6), _ ..");
+    //let valid_parser_code = String::from("(5,6), _ ..");
+    let valid_parser_code = String::from("0o____01010___111.01____name");
 
     let tokens = match Lexer::new(valid_parser_code).lex() {
         Ok(tokens) => tokens,


### PR DESCRIPTION
multiple underscores '_' are now valid

E.g 211__123___12  [valid]
      211_________123664____553535 [valid]

Number literals can be formatted with as many underscores '_' as the programmer like.